### PR TITLE
Play nice with https://github.com/shpakovski/Popup.

### DIFF
--- a/AXStatusItemPopup/AXStatusItemPopup.m
+++ b/AXStatusItemPopup/AXStatusItemPopup.m
@@ -18,6 +18,7 @@
     BOOL _active;
     NSImageView *_imageView;
     NSStatusItem *_statusItem;
+    NSMenu *_dummyMenu;
     NSPopover *_popover;
     id _popoverTransiencyMonitor;
 }
@@ -56,6 +57,7 @@
         
         self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
         self.statusItem.view = self;
+        _dummyMenu = [[NSMenu alloc] init];
         
         _active = NO;
         _animated = YES;
@@ -158,6 +160,7 @@
     
     if (!_popover.isShown) {
         _popover.animates = animated;
+        [self.statusItem popUpStatusItemMenu:_dummyMenu];
         [_popover showRelativeToRect:self.frame ofView:self preferredEdge:NSMinYEdge];
         _popoverTransiencyMonitor = [NSEvent addGlobalMonitorForEventsMatchingMask:NSLeftMouseDownMask|NSRightMouseDownMask handler:^(NSEvent* event) {
             [self hidePopover];


### PR DESCRIPTION
Many projects use shpakovski/Popup, but AXStatusItemPopup has a problem when a Popup-based application is also in the menu bar:
1. Click the Popup application menu bar icon.
2. Click the AXStatusItemPopup menu bar icon.
3. See below result.

![screenshot_problem](https://f.cloud.github.com/assets/2056763/1710823/9cd6b1e4-613c-11e3-868a-e54fc0af9739.png)

This commit fixes the problem by presenting a dummy (empty) NSMenu from the NSStatusItem, which causes the Popup panel to close when the AXStatusItemPopup menu bar icon is clicked.
