### PR TITLE
added block-drawn option, cleaned up code

### DIFF
--- a/AXStatusItemPopup/AXStatusItemPopup.h
+++ b/AXStatusItemPopup/AXStatusItemPopup.h
@@ -1,35 +1,32 @@
-//
-//  StatusItemPopup.h
-//  StatusItemPopup
-//
-//  Created by Alexander Schuch on 06/03/13.
-//  Copyright (c) 2013 Alexander Schuch. All rights reserved.
-//
+
+//  StatusItemPopup.h  StatusItemPopup
+//  Created by Alexander Schuch on 06/03/13. Copyright (c) 2013 Alexander Schuch. All rights reserved.
 
 #import <Cocoa/Cocoa.h>
 
 @interface AXStatusItemPopup : NSView
 
+typedef void(^StatusBlock)(AXStatusItemPopup*pop);
+
 // properties
-@property(assign, nonatomic, getter=isActive) BOOL active;
-@property(assign, nonatomic) BOOL animated;
-@property(strong, nonatomic) NSImage *image;
-@property(strong, nonatomic) NSImage *alternateImage;
-@property(strong, nonatomic) NSStatusItem *statusItem;
-
-
+@property (nonatomic)                  BOOL   animated;
+@property (nonatomic,getter=isActive)  BOOL   active;
+@property (nonatomic,copy)      StatusBlock   drawBlock;
+@property (nonatomic)          NSStatusItem * statusItem;
+@property (nonatomic)               NSImage * image,
+                                            * alternateImage;
 // init
-- (id)initWithViewController:(NSViewController *)controller;
-- (id)initWithViewController:(NSViewController *)controller image:(NSImage *)image;
-- (id)initWithViewController:(NSViewController *)controller image:(NSImage *)image alternateImage:(NSImage *)alternateImage;
-
+- (id) initWithViewController:(NSViewController*)c;
+- (id) initWithViewController:(NSViewController*)c image:(NSImage*)i;
+- (id) initWithViewController:(NSViewController*)c image:(NSImage*)i alternateImage:(NSImage*)a;
+- (id) initWithViewController:(NSViewController*)c drawnWithBlock:(StatusBlock)b;
 
 // show / hide popover
-- (void)showPopover;
-- (void)showPopoverAnimated:(BOOL)animated;
-- (void)hidePopover;
+- (void) showPopoverAnimated:(BOOL)animated;
+- (void) showPopover;
+- (void) hidePopover;
 
 // view size
-- (void)setContentSize:(CGSize *)size;
+- (void) setContentSize:(CGSize)size;
 
 @end

--- a/AXStatusItemPopup/AXStatusItemPopup.m
+++ b/AXStatusItemPopup/AXStatusItemPopup.m
@@ -1,191 +1,141 @@
-//
-//  StatusItemPopup.m
-//  StatusItemPopup
-//
-//  Created by Alexander Schuch on 06/03/13.
-//  Copyright (c) 2013 Alexander Schuch. All rights reserved.
-//
+
+//  StatusItemPopup.m  StatusItemPopup
+//  Created by Alexander Schuch on 06/03/13. Copyright (c) 2013 Alexander Schuch. All rights reserved.
 
 #import "AXStatusItemPopup.h"
 
 #define kMinViewWidth 22
+#define FRAME (NSRect){NSZeroPoint,{kMinViewWidth,NSStatusBar.systemStatusBar.thickness}}
 
-//
-// Private variables
-//
-@interface AXStatusItemPopup () {
-    NSViewController *_viewController;
-    BOOL _active;
-    NSImageView *_imageView;
-    NSStatusItem *_statusItem;
-    NSPopover *_popover;
-    id _popoverTransiencyMonitor;
-}
-@end
-
-///////////////////////////////////
-
-//
 // Implementation
-//
-@implementation AXStatusItemPopup
+@implementation AXStatusItemPopup {
 
-- (id)initWithViewController:(NSViewController *)controller
-{
-    return [self initWithViewController:controller image:nil];
+@private
+  NSViewController * _viewController;
+       NSImageView * _imageView;
+      NSStatusItem * _statusItem;
+         NSPopover * _popover;
+                id   _popoverTransiencyMonitor;
+              BOOL   _active;
 }
 
 - (id)initWithViewController:(NSViewController *)controller image:(NSImage *)image
 {
-    return [self initWithViewController:controller image:image alternateImage:nil];
+  return [self initWithViewController:controller image:image alternateImage:nil];
 }
 
-- (id)initWithViewController:(NSViewController *)controller image:(NSImage *)image alternateImage:(NSImage *)alternateImage
+- (id) initWithViewController:(NSViewController*)vc {
+
+  self            = [super initWithFrame:FRAME]; return self ?
+  _viewController = vc,
+  (_statusItem    = [NSStatusBar.systemStatusBar statusItemWithLength:NSSquareStatusItemLength]).view = self,
+  _active         = NO,
+  _animated       = YES, self : nil;
+}
+
+- (id)initWithViewController:(NSViewController*)vc image:(NSImage *)img alternateImage:(NSImage *)alt
 {
-    CGFloat height = [NSStatusBar systemStatusBar].thickness;
-    
-    self = [super initWithFrame:NSMakeRect(0, 0, kMinViewWidth, height)];
-    if (self) {
-        _viewController = controller;
-        
-        self.image = image;
-        self.alternateImage = alternateImage;
-        
-        _imageView = [[NSImageView alloc] initWithFrame:NSMakeRect(0, 0, kMinViewWidth, height)];
-        [self addSubview:_imageView];
-        
-        self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
-        self.statusItem.view = self;
-        
-        _active = NO;
-        _animated = YES;
-    }
-    return self;
+  self                        = [self initWithViewController:vc];
+  _image                      = img;
+  _alternateImage             = alt;
+  [self addSubview:_imageView = [NSImageView.alloc initWithFrame:self.bounds]];
+  _imageView.alignment        = NSImageAlignCenter;
+  _imageView.imageScaling     =  NSImageScaleProportionallyUpOrDown;
+  return self;
 }
 
+- (id)initWithViewController:(NSViewController*)vc drawnWithBlock:(StatusBlock)b {
 
-////////////////////////////////////
+  self = [self initWithViewController:vc]; return self ? _drawBlock = [b copy], self : nil;
+}
+
 #pragma mark - Drawing
-////////////////////////////////////
 
 - (void)drawRect:(NSRect)dirtyRect
 {
-    // set view background color
-    if (_active) {
-        [[NSColor selectedMenuItemColor] setFill];
-    } else {
-        [[NSColor clearColor] setFill];
-    }
-    NSRectFill(dirtyRect);
-    
-    // set image
-    NSImage *image = (_active ? _alternateImage : _image);
-    _imageView.image = image;
+  if (_drawBlock) return _drawBlock(self); // if we draw in a block, do it.. and bail.
+
+  // set view background color
+  [_active ? NSColor.selectedMenuItemColor : NSColor.clearColor setFill];
+
+  NSRectFill(dirtyRect);
+
+  _imageView.image = _active ? _alternateImage : _image;  // set image
 }
 
-////////////////////////////////////
 #pragma mark - Position / Size
-////////////////////////////////////
 
 - (void)setContentSize:(CGSize)size
 {
-    _popover.contentSize = size;
+  _popover.contentSize = size;
 }
 
-////////////////////////////////////
 #pragma mark - Mouse Actions
-////////////////////////////////////
 
 - (void)mouseDown:(NSEvent *)theEvent
 {
-    if (_popover.isShown) {
-        [self hidePopover];
-    } else {
-        [self showPopover];
-    }    
+  _popover.isShown ? [self hidePopover] : [self showPopover];
 }
 
-////////////////////////////////////
 #pragma mark - Setter
-////////////////////////////////////
 
 - (void)setActive:(BOOL)active
 {
-    _active = active;
-    [self setNeedsDisplay:YES];
+  _active = active;
+  [self setNeedsDisplay:YES];
 }
 
 - (void)setImage:(NSImage *)image
 {
-    _image = image;
-    [self updateViewFrame];
+  _image = image;
+  [self updateViewFrame];
 }
 
 - (void)setAlternateImage:(NSImage *)image
 {
-    _alternateImage = image;
-    if (!image && _image) {
-        _alternateImage = _image;
-    }
-    [self updateViewFrame];
+  _alternateImage = image ?: image;
+  [self updateViewFrame];
 }
 
-////////////////////////////////////
 #pragma mark - Helper
-////////////////////////////////////
 
 - (void)updateViewFrame
 {
-    CGFloat width = MAX(MAX(kMinViewWidth, self.alternateImage.size.width), self.image.size.width);
-    CGFloat height = [NSStatusBar systemStatusBar].thickness;
-    
-    NSRect frame = NSMakeRect(0, 0, width, height);
-    self.frame = frame;
-    _imageView.frame = frame;
-    
-    [self setNeedsDisplay:YES];
+  self.frame = _imageView.frame = (NSRect){{0,0},
+    {MAX(MAX(kMinViewWidth, self.alternateImage.size.width), self.image.size.width),
+                                            NSStatusBar.systemStatusBar.thickness}};
+  [self setNeedsDisplay:YES];
 }
 
-
-////////////////////////////////////
 #pragma mark - Show / Hide Popover
-////////////////////////////////////
 
 - (void)showPopover
 {
-    [self showPopoverAnimated:_animated];
+  [self showPopoverAnimated:_animated];
 }
 
 - (void)showPopoverAnimated:(BOOL)animated
 {
-    self.active = YES;
-    
-    if (!_popover) {
-        _popover = [[NSPopover alloc] init];
-        _popover.contentViewController = _viewController;
-    }
-    
-    if (!_popover.isShown) {
-        _popover.animates = animated;
-        [_popover showRelativeToRect:self.frame ofView:self preferredEdge:NSMinYEdge];
-        _popoverTransiencyMonitor = [NSEvent addGlobalMonitorForEventsMatchingMask:NSLeftMouseDownMask|NSRightMouseDownMask handler:^(NSEvent* event) {
-            [self hidePopover];
-        }];
-    }
+  self.active = YES;
+
+  _popover = _popover ?: ({ _popover = NSPopover.new;
+      _popover.contentViewController = _viewController; _popover; });
+
+  if (_popover.isShown) return;
+  _popover.animates = animated;
+  [_popover showRelativeToRect:self.frame ofView:self preferredEdge:NSMinYEdge];
+  _popoverTransiencyMonitor = [NSEvent addGlobalMonitorForEventsMatchingMask:NSLeftMouseDownMask|NSRightMouseDownMask handler:^(NSEvent* event) {
+    [self hidePopover];
+  }];
 }
 
 - (void)hidePopover
 {
-    self.active = NO;
-    
-    if (_popover && _popover.isShown) {
-        [_popover close];
+  self.active = NO;
 
-		if (_popoverTransiencyMonitor) {
-            [NSEvent removeMonitor:_popoverTransiencyMonitor];
-            _popoverTransiencyMonitor = nil;
-        }
-    }
+  if (_popover && _popover.isShown) [_popover close];
+  if (_popoverTransiencyMonitor)
+    [NSEvent removeMonitor:_popoverTransiencyMonitor], _popoverTransiencyMonitor = nil;
 }
 
 @end


### PR DESCRIPTION
![140524-0004](https://cloud.githubusercontent.com/assets/262517/3074149/9767a9bc-e327-11e3-8ce2-18b44f668b17.png)

![screencrop](https://cloud.githubusercontent.com/assets/262517/3074166/0e03c16e-e328-11e3-8330-d4d0a40e3313.png)

![140524-0003](https://cloud.githubusercontent.com/assets/262517/3074152/9d7caa8c-e327-11e3-8128-0d1c55f0f410.png)

with an implementation (as shown) of...

``` objc

statusItemPopup = [AXStatusItemPopup.alloc 
              initWithViewController:popupVC
                      drawnWithBlock:^(AXStatusItemPopup *p) {
    CGFloat h = NSHeight(p.frame);
    NSPoint o = (NSPoint){( (NSWidth(p.frame) - h) / 2) + 4, p.frame.origin.y + 5};
    NSBezierPath* x = [NSBezierPath bezierPathWithOvalInRect:(NSRect){o,{h-8,h-8}}];
    [p.isActive ? NSColor.redColor : NSColor.yellowColor set], [x fill];
    [x setLineWidth:2], [p.isActive ? NSColor.whiteColor : NSColor.blackColor set], [x stroke];
}];
```
