### PR TITLE
Fix setContentSize parameter and support right click

### DIFF
--- a/AXStatusItemPopup/AXStatusItemPopup.h
+++ b/AXStatusItemPopup/AXStatusItemPopup.h
@@ -30,6 +30,6 @@
 - (void)hidePopover;
 
 // view size
-- (void)setContentSize:(CGSize *)size;
+- (void)setContentSize:(CGSize)size;
 
 @end

--- a/AXStatusItemPopup/AXStatusItemPopup.m
+++ b/AXStatusItemPopup/AXStatusItemPopup.m
@@ -107,6 +107,11 @@
     }    
 }
 
+- (void)rightMouseDown:(NSEvent *)theEvent
+{
+    [self mouseDown:nil];
+}
+
 ////////////////////////////////////
 #pragma mark - Setter
 ////////////////////////////////////


### PR DESCRIPTION
Noticed a typo in '- (void)setContentSize:(CGSize)size'. Should get rid of the warning.

Also added an override for '- (void)rightMouseDown:(NSEvent *)theEvent' so it show the popover when the right mouse button is pressed (Fantastical, Dropbox etc. and regular NSStatusItem menus all have this behaviour).
